### PR TITLE
ci: harden image build and release pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,59 +6,242 @@ on:
     paths:
       - "Dockerfile"
       - "healthcheck.go"
+      - ".github/workflows/main.yml"
+      - "renovate.json5"
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
-  buildx:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+      renovate: ${{ steps.filter.outputs.renovate }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            build:
+              - "Dockerfile"
+              - "healthcheck.go"
+            renovate:
+              - ".github/workflows/main.yml"
+              - "renovate.json5"
+
+  actionlint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.8@sha256:96d4a8c87dbbfb3bdd324f8fdc285fc3df5261e2decc619a4dd7e8ee52bbfd46
+        with:
+          args: -shellcheck=shellcheck .github/workflows/main.yml
+
+  buildx:
+    runs-on: ubuntu-latest
+    needs: detect
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Verify distroless base image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DISTROLESS_REF=$(awk '/^FROM gcr\.io\/distroless\// {print $2; exit}' Dockerfile)
+          if [[ -z "${DISTROLESS_REF}" ]]; then
+            echo "No distroless base image found in Dockerfile" >&2
+            exit 1
+          fi
+
+          echo "Verifying ${DISTROLESS_REF}"
+          cosign verify "${DISTROLESS_REF}" \
+            --certificate-oidc-issuer https://accounts.google.com \
+            --certificate-identity keyless@distroless.iam.gserviceaccount.com
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: |
+            sholdee/caddy-proxy-cloudflare:ci
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: detect
+    if: github.event_name == 'push' && needs.detect.outputs.build == 'true'
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set env
-        run: echo "TAG=$(echo $(date +%Y.%m.%d))" >> $GITHUB_ENV
+        run: echo "TAG=$(date +%Y.%m.%d)" >> "$GITHUB_ENV"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Verify distroless base image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DISTROLESS_REF=$(awk '/^FROM gcr\.io\/distroless\// {print $2; exit}' Dockerfile)
+          if [[ -z "${DISTROLESS_REF}" ]]; then
+            echo "No distroless base image found in Dockerfile" >&2
+            exit 1
+          fi
+
+          echo "Verifying ${DISTROLESS_REF}"
+          cosign verify "${DISTROLESS_REF}" \
+            --certificate-oidc-issuer https://accounts.google.com \
+            --certificate-identity keyless@distroless.iam.gserviceaccount.com
 
       - name: Docker Login to Docker Hub
-        if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker Login to GHCR
-        if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Build and Push to Docker Hub and GHCR
-        uses: docker/build-push-action@v7
+      - name: Build and push images
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' }}
+          push: true
           tags: |
             sholdee/caddy-proxy-cloudflare:latest
             sholdee/caddy-proxy-cloudflare:${{ env.TAG }}
             ghcr.io/${{ github.repository_owner }}/caddy-proxy-cloudflare:latest
             ghcr.io/${{ github.repository_owner }}/caddy-proxy-cloudflare:${{ env.TAG }}
 
+      - name: Sign image digests
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DOCKERHUB_IMAGE: docker.io/sholdee/caddy-proxy-cloudflare
+          GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/caddy-proxy-cloudflare
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for image in "${DOCKERHUB_IMAGE}" "${GHCR_IMAGE}"; do
+            echo "Signing ${image}@${DIGEST}"
+            cosign sign --yes "${image}@${DIGEST}"
+          done
+
       - name: Create GitHub Release
-        if: ${{ github.event_name == 'push' }}
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ env.TAG }}
           allowUpdates: true
           makeLatest: true
+
+  renovate:
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.renovate == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate Renovate config
+        run: npx --yes --package renovate@43.141.6 -- renovate-config-validator --strict
+
+  gate:
+    runs-on: ubuntu-latest
+    needs:
+      - detect
+      - actionlint
+      - buildx
+      - publish
+      - renovate
+    if: always()
+    steps:
+      - name: Check required job results
+        env:
+          ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
+          BUILDX_RESULT: ${{ needs.buildx.result }}
+          DETECT_RESULT: ${{ needs.detect.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          RENOVATE_RESULT: ${{ needs.renovate.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${DETECT_RESULT}" != "success" ]]; then
+            echo "detect failed with result: ${DETECT_RESULT}" >&2
+            exit 1
+          fi
+
+          if [[ "${ACTIONLINT_RESULT}" != "success" ]]; then
+            echo "actionlint failed with result: ${ACTIONLINT_RESULT}" >&2
+            exit 1
+          fi
+
+          check_optional_job() {
+            local job="$1"
+            local result="$2"
+
+            case "${result}" in
+              success|skipped)
+                ;;
+              *)
+                echo "${job} failed with result: ${result}" >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          check_optional_job buildx "${BUILDX_RESULT}"
+          check_optional_job publish "${PUBLISH_RESULT}"
+          check_optional_job renovate "${RENOVATE_RESULT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG GOLANG_VERSION=1.26.1
-
-FROM golang:${GOLANG_VERSION}-trixie AS gobuild
+FROM golang:1.26.3-trixie@sha256:38a4ee13cf5097699c2dfc949f0930394afba0fca853d7094eace21037981f01 AS gobuild
 
 WORKDIR /go/src/github.com/caddyserver/xcaddy/cmd/xcaddy
 
@@ -23,7 +21,7 @@ WORKDIR /go/src/healthcheck
 COPY healthcheck.go .
 RUN go build -o /healthcheck -ldflags="-s -w" healthcheck.go
 
-FROM gcr.io/distroless/static-debian13:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
 EXPOSE 80 443 2019
 
 ENV XDG_CONFIG_HOME=/config

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,6 +20,25 @@
       ],
     },
     {
+      description: 'Rate-limit and automerge Renovate self-updates (multiple releases per day)',
+      matchPackageNames: [
+        'renovate',
+      ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+      schedule: [
+        'before 2am on monday',
+      ],
+      minimumReleaseAge: '7 days',
+      automerge: true,
+    },
+    {
+      description: 'Update Go builder image promptly',
+      matchManagers: [
+        'dockerfile',
+      ],
       matchDatasources: [
         'docker',
       ],
@@ -54,6 +73,20 @@
       datasourceTemplate: 'go',
       packageNameTemplate: '{{packageName}}',
       versioningTemplate: 'semver',
+    },
+    {
+      customType: 'regex',
+      description: [
+        'Process npx tool versions in CI workflows',
+      ],
+      managerFilePatterns: [
+        '/\\.github/workflows/.*\\.ya?ml$/',
+      ],
+      matchStrings: [
+        'npx --yes (?:--package )?(?<depName>[\\w-]+)@(?<currentValue>[\\d.]+)',
+      ],
+      datasourceTemplate: 'npm',
+      versioningTemplate: 'npm',
     },
   ],
 }


### PR DESCRIPTION
## Summary
- Pin Docker base images by digest and third-party GitHub Actions by commit SHA.
- Add actionlint, distroless cosign verification, and push-only image signing.
- Replace custom path detection with pinned dorny/paths-filter and keep gate as the required status check.

## Test plan
- actionlint -shellcheck=shellcheck .github/workflows/main.yml
- docker run --rm -v "/Users/ethan.shold/.config/superpowers/worktrees/caddy-proxy-cloudflare/go-builder-security:/repo" -w /repo rhysd/actionlint:1.7.8@sha256:96d4a8c87dbbfb3bdd324f8fdc285fc3df5261e2decc619a4dd7e8ee52bbfd46 -shellcheck=shellcheck .github/workflows/main.yml
- npx --yes --package renovate@43.141.6 -- renovate-config-validator --strict
- Renovate dry run
- cosign verify distroless base image
- go test healthcheck.go
- go vet healthcheck.go
- docker buildx build --platform linux/amd64 --load