### PR TITLE
ci: skip image builds for docs-only PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
   buildx:
     runs-on: ubuntu-latest
     needs: detect
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.detect.outputs.build == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Skip the expensive PR image build unless Dockerfile or healthcheck.go changes.
- Keep actionlint and gate running for every PR.

## Test plan
- actionlint -shellcheck=shellcheck .github/workflows/main.yml
- git diff --check