### PR TITLE
ci: add linux binary release artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      binary: ${{ steps.filter.outputs.binary }}
       build: ${{ steps.filter.outputs.build }}
       renovate: ${{ steps.filter.outputs.renovate }}
     steps:
@@ -38,6 +39,11 @@ jobs:
               - "Dockerfile"
               - "healthcheck.go"
               - "healthcheck_test.go"
+            binary:
+              - "Dockerfile"
+              - "healthcheck.go"
+              - "healthcheck_test.go"
+              - ".github/workflows/main.yml"
             renovate:
               - ".github/workflows/main.yml"
               - "renovate.json5"
@@ -96,20 +102,93 @@ jobs:
           cache-from: type=gha,scope=caddy-proxy-cloudflare
           cache-to: type=gha,scope=caddy-proxy-cloudflare,mode=max,ignore-error=true
 
-  publish:
+  binary-check:
     runs-on: ubuntu-latest
     needs: detect
-    if: github.event_name == 'push' && needs.detect.outputs.build == 'true'
-    permissions:
-      contents: write
-      id-token: write
-      packages: write
+    if: github.event_name == 'pull_request' && needs.detect.outputs.binary == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set env
-        run: echo "TAG=$(date +%Y.%m.%d)" >> "$GITHUB_ENV"
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Export binaries
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          target: binary-export
+          platforms: linux/amd64,linux/arm64
+          outputs: type=local,dest=dist-raw
+          cache-from: type=gha,scope=caddy-proxy-cloudflare
+          cache-to: type=gha,scope=caddy-proxy-cloudflare,mode=max,ignore-error=true
+
+      - name: Validate binary artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          for arch in amd64 arm64; do
+            src="$(find dist-raw -type f -name "caddy-proxy-cloudflare-linux-${arch}" -print -quit)"
+            if [[ -z "${src}" ]]; then
+              echo "Missing binary for linux/${arch}" >&2
+              find dist-raw -maxdepth 4 -type f -print >&2
+              exit 1
+            fi
+            cp "${src}" "dist/caddy-proxy-cloudflare-linux-${arch}"
+          done
+
+          chmod 0755 dist/caddy-proxy-cloudflare-linux-*
+          cd dist
+          sha256sum caddy-proxy-cloudflare-linux-* > checksums-sha256.txt
+          cat checksums-sha256.txt
+
+  release-meta:
+    runs-on: ubuntu-latest
+    needs:
+      - detect
+      - actionlint
+    if: github.event_name == 'push' && needs.detect.outputs.build == 'true'
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="$(date -u '+v%Y.%-m%d.%-H%M%S')"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+
+          git tag "${TAG}" "${GITHUB_SHA}"
+          git push origin "refs/tags/${TAG}"
+
+  publish-image:
+    runs-on: ubuntu-latest
+    needs:
+      - detect
+      - release-meta
+    if: github.event_name == 'push' && needs.detect.outputs.build == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -158,9 +237,9 @@ jobs:
           push: true
           tags: |
             sholdee/caddy-proxy-cloudflare:latest
-            sholdee/caddy-proxy-cloudflare:${{ env.TAG }}
+            sholdee/caddy-proxy-cloudflare:${{ needs.release-meta.outputs.tag }}
             ghcr.io/${{ github.repository_owner }}/caddy-proxy-cloudflare:latest
-            ghcr.io/${{ github.repository_owner }}/caddy-proxy-cloudflare:${{ env.TAG }}
+            ghcr.io/${{ github.repository_owner }}/caddy-proxy-cloudflare:${{ needs.release-meta.outputs.tag }}
           cache-from: type=gha,scope=caddy-proxy-cloudflare
           cache-to: type=gha,scope=caddy-proxy-cloudflare,mode=max,ignore-error=true
 
@@ -178,12 +257,132 @@ jobs:
             cosign sign --yes "${image}@${DIGEST}"
           done
 
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+  binaries:
+    runs-on: ubuntu-latest
+    needs:
+      - detect
+      - release-meta
+    if: github.event_name == 'push' && needs.detect.outputs.build == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Export binaries
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
-          tag: ${{ env.TAG }}
-          allowUpdates: true
-          makeLatest: true
+          context: .
+          file: ./Dockerfile
+          target: binary-export
+          platforms: linux/amd64,linux/arm64
+          outputs: type=local,dest=dist-raw
+          cache-from: type=gha,scope=caddy-proxy-cloudflare
+          cache-to: type=gha,scope=caddy-proxy-cloudflare,mode=max,ignore-error=true
+
+      - name: Prepare binary artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          for arch in amd64 arm64; do
+            src="$(find dist-raw -type f -name "caddy-proxy-cloudflare-linux-${arch}" -print -quit)"
+            if [[ -z "${src}" ]]; then
+              echo "Missing binary for linux/${arch}" >&2
+              find dist-raw -maxdepth 4 -type f -print >&2
+              exit 1
+            fi
+            cp "${src}" "dist/caddy-proxy-cloudflare-linux-${arch}"
+          done
+
+          chmod 0755 dist/caddy-proxy-cloudflare-linux-*
+          cd dist
+          sha256sum caddy-proxy-cloudflare-linux-* > checksums-sha256.txt
+          cat checksums-sha256.txt
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign checksum manifest
+        run: |
+          cosign sign-blob --yes \
+            --bundle dist/checksums-sha256.txt.sigstore.json \
+            dist/checksums-sha256.txt
+
+      - name: Attest binaries
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-checksums: dist/checksums-sha256.txt
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries
+          path: dist/
+          retention-days: 1
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - detect
+      - release-meta
+      - publish-image
+      - binaries
+    if: github.event_name == 'push' && needs.detect.outputs.build == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Download binary artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binaries
+          path: dist
+
+      - name: Verify downloaded binary artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cd dist
+          sha256sum --check checksums-sha256.txt
+          test -f checksums-sha256.txt.sigstore.json
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_DIGEST: ${{ needs.publish-image.outputs.digest }}
+          TAG: ${{ needs.release-meta.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cat > release-notes.md <<EOF
+          Image:
+          - ghcr.io/${GITHUB_REPOSITORY_OWNER}/caddy-proxy-cloudflare:${TAG}
+          - docker.io/sholdee/caddy-proxy-cloudflare:${TAG}
+
+          Image digest:
+          ${IMAGE_DIGEST}
+
+          Binaries:
+          - caddy-proxy-cloudflare-linux-amd64
+          - caddy-proxy-cloudflare-linux-arm64
+          - checksums-sha256.txt
+          - checksums-sha256.txt.sigstore.json
+          EOF
+
+          gh release create "${TAG}" dist/* \
+            --title "${TAG}" \
+            --notes-file release-notes.md \
+            --verify-tag \
+            --latest
 
   renovate:
     runs-on: ubuntu-latest
@@ -201,17 +400,25 @@ jobs:
     needs:
       - detect
       - actionlint
+      - binary-check
       - buildx
-      - publish
+      - release-meta
+      - publish-image
+      - binaries
+      - release
       - renovate
     if: always()
     steps:
       - name: Check required job results
         env:
           ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
+          BINARY_CHECK_RESULT: ${{ needs.binary-check.result }}
+          BINARIES_RESULT: ${{ needs.binaries.result }}
           BUILDX_RESULT: ${{ needs.buildx.result }}
           DETECT_RESULT: ${{ needs.detect.result }}
-          PUBLISH_RESULT: ${{ needs.publish.result }}
+          PUBLISH_IMAGE_RESULT: ${{ needs.publish-image.result }}
+          RELEASE_META_RESULT: ${{ needs.release-meta.result }}
+          RELEASE_RESULT: ${{ needs.release.result }}
           RENOVATE_RESULT: ${{ needs.renovate.result }}
         shell: bash
         run: |
@@ -241,6 +448,10 @@ jobs:
             esac
           }
 
+          check_optional_job binary-check "${BINARY_CHECK_RESULT}"
+          check_optional_job binaries "${BINARIES_RESULT}"
           check_optional_job buildx "${BUILDX_RESULT}"
-          check_optional_job publish "${PUBLISH_RESULT}"
+          check_optional_job release-meta "${RELEASE_META_RESULT}"
+          check_optional_job publish-image "${PUBLISH_IMAGE_RESULT}"
+          check_optional_job release "${RELEASE_RESULT}"
           check_optional_job renovate "${RENOVATE_RESULT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ COPY healthcheck*.go .
 RUN go test healthcheck.go healthcheck_test.go && \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /healthcheck -ldflags="-s -w" healthcheck.go
 
+FROM scratch AS binary-export
+ARG TARGETOS
+ARG TARGETARCH
+COPY --from=gobuild /go/src/github.com/caddyserver/xcaddy/cmd/caddy /caddy-proxy-cloudflare-${TARGETOS}-${TARGETARCH}
+
 FROM gcr.io/distroless/static-debian13:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
 EXPOSE 80 443 2019
 


### PR DESCRIPTION
## Summary
- add a Dockerfile binary-export target for the custom Caddy binary
- add PR-only linux amd64/arm64 binary export validation
- split release publishing into tag metadata, image publish, binary artifacts, and GitHub Release jobs
- attach raw linux binaries, checksums, checksum sigstore bundle, and build provenance on release

## Validation
- actionlint -shellcheck=shellcheck .github/workflows/main.yml
- go test healthcheck.go healthcheck_test.go
- go build -o /tmp/caddy-proxy-cloudflare-healthcheck healthcheck.go
- docker buildx build --platform linux/amd64,linux/arm64 --target binary-export --output type=local,dest=/private/tmp/caddy-binary-export-test .
- checksum normalization script against exported binaries
- docker buildx build --platform linux/amd64,linux/arm64 -t caddy-proxy-cloudflare:binary-artifacts-check .