### PR TITLE
ci: fix release job repository context

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -379,6 +379,7 @@ jobs:
           EOF
 
           gh release create "${TAG}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
             --title "${TAG}" \
             --notes-file release-notes.md \
             --verify-tag \


### PR DESCRIPTION
Fixes the release failure in run 25580150564.

The release job downloads artifacts without checking out the repository. That is fine, but gh release create still needs an explicit repository context. Passing --repo ${GITHUB_REPOSITORY} avoids the implicit git worktree lookup that failed with fatal: not a git repository.

Validation:
- actionlint -shellcheck=shellcheck .github/workflows/main.yml