### PR TITLE
feat: add caddy geoip2 module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build \
     --with github.com/WeidiDeng/caddy-cloudflare-ip@v0.0.0-20231130002422-f53b62aa13cb \
     --with github.com/hslatman/caddy-crowdsec-bouncer/http@v0.12.1 \
     --with github.com/hslatman/caddy-crowdsec-bouncer/appsec@v0.12.1 \
-    --with github.com/ggicci/caddy-jwt@v1.1.2
+    --with github.com/ggicci/caddy-jwt@v1.1.2 \
+    --with github.com/zhangjiayin/caddy-geoip2@v0.0.0-20251231005803-9e40d38250b4
 
 WORKDIR /go/src/healthcheck
 COPY healthcheck*.go .

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The image is built from the repository `Dockerfile` with:
 - `github.com/hslatman/caddy-crowdsec-bouncer/http`
 - `github.com/hslatman/caddy-crowdsec-bouncer/appsec`
 - `github.com/ggicci/caddy-jwt`
+- `github.com/zhangjiayin/caddy-geoip2`
 
 The final image runs as `nonroot:nonroot` on a pinned distroless base image and includes a small healthcheck binary.
 


### PR DESCRIPTION
Adds github.com/zhangjiayin/caddy-geoip2 to the xcaddy build and lists it in the README module list.

Validation:
- actionlint -shellcheck=shellcheck .github/workflows/main.yml
- docker buildx build --platform linux/amd64 --target binary-export --output type=local,dest=/private/tmp/caddy-geoip2-binary-test .
- docker buildx build --platform linux/amd64 --load -t caddy-proxy-cloudflare:geoip2-test .
- docker run --rm --platform linux/amd64 --entrypoint /bin/caddy caddy-proxy-cloudflare:geoip2-test list-modules | rg "geoip|cloudflare|jwt|crowdsec|docker"