### PR TITLE
ci: normalize release CalVer components

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          TAG="$(date -u '+v%Y.%-m%d.%-H%M%S')"
+          read -r YEAR MONTH DAY HOUR MINUTE SECOND < <(date -u '+%Y %m %d %H %M %S')
+          MDD=$((10#${MONTH} * 100 + 10#${DAY}))
+          HMMSS=$((10#${HOUR} * 10000 + 10#${MINUTE} * 100 + 10#${SECOND}))
+          TAG="v${YEAR}.${MDD}.${HMMSS}"
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
 
           git tag "${TAG}" "${GITHUB_SHA}"

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ docker.io/sholdee/caddy-proxy-cloudflare
 Recommended reference styles:
 
 ```text
-# Production: pin a date tag and digest.
-ghcr.io/sholdee/caddy-proxy-cloudflare:YYYY.MM.DD@sha256:<digest>
+# Production: pin a release tag and digest.
+ghcr.io/sholdee/caddy-proxy-cloudflare:vYYYY.MDD.HMMSS@sha256:<digest>
 
-# Normal updates: use the date tag.
-ghcr.io/sholdee/caddy-proxy-cloudflare:YYYY.MM.DD
+# Normal updates: use the release tag.
+ghcr.io/sholdee/caddy-proxy-cloudflare:vYYYY.MDD.HMMSS
 
 # Quick tests only.
 ghcr.io/sholdee/caddy-proxy-cloudflare:latest
@@ -213,16 +213,16 @@ If Caddy is not issuing certificates, check the Cloudflare token scope, DNS zone
 
 ## Updating Digests
 
-Resolve the digest for a date tag:
+Resolve the digest for a release tag:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/sholdee/caddy-proxy-cloudflare:YYYY.MM.DD
+docker buildx imagetools inspect ghcr.io/sholdee/caddy-proxy-cloudflare:vYYYY.MDD.HMMSS
 ```
 
 Copy the top-level manifest digest into Compose:
 
 ```yaml
-image: ghcr.io/sholdee/caddy-proxy-cloudflare:YYYY.MM.DD@sha256:<digest>
+image: ghcr.io/sholdee/caddy-proxy-cloudflare:vYYYY.MDD.HMMSS@sha256:<digest>
 ```
 
 If you run Renovate against your Compose repository, it can also maintain digest-pinned image references.


### PR DESCRIPTION
Applies the same robust CalVer arithmetic used in crd-schema-publisher so release tags have no leading zeros in SemVer numeric components.

The workflow now parses fixed-width UTC date fields and computes:
- MDD = month * 100 + day
- HMMSS = hour * 10000 + minute * 100 + second

This preserves positional zeros after non-zero digits while removing leading zeros for midnight edge cases.

Also updates README image examples to use the current vYYYY.MDD.HMMSS release tag format.

Validation:
- actionlint -shellcheck=shellcheck .github/workflows/main.yml
- local bash pattern table for midnight, embedded-zero, 08/09-style, and max-time cases