### PR TITLE
ci: format release artifact notes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -375,22 +375,16 @@ jobs:
           )"
 
           artifact_notes="$(cat <<EOF
-          Image:
-          - ghcr.io/${GITHUB_REPOSITORY_OWNER}/caddy-proxy-cloudflare:${TAG}
-          - docker.io/sholdee/caddy-proxy-cloudflare:${TAG}
-
-          Image digest:
-          ${IMAGE_DIGEST}
-
-          Binaries:
-          - caddy-proxy-cloudflare-linux-amd64
-          - caddy-proxy-cloudflare-linux-arm64
-          - checksums-sha256.txt
-          - checksums-sha256.txt.sigstore.json
+          **GHCR image:** \`ghcr.io/${GITHUB_REPOSITORY_OWNER}/caddy-proxy-cloudflare:${TAG}@${IMAGE_DIGEST}\`
+          **Docker Hub image:** \`docker.io/sholdee/caddy-proxy-cloudflare:${TAG}@${IMAGE_DIGEST}\`
+          **Checksums:** \`checksums-sha256.txt\` (Sigstore bundle: \`checksums-sha256.txt.sigstore.json\`)
+          **Binaries:** \`caddy-proxy-cloudflare-linux-amd64\`, \`caddy-proxy-cloudflare-linux-arm64\`
           EOF
           )"
 
           release_notes="${generated_notes}
+
+          ---
 
           ${artifact_notes}"
 


### PR DESCRIPTION
Formats caddy release artifact notes like the crd-schema-publisher release notes: generated notes first, a separator, then compact bold key/value lines with backticked image, checksum, and binary references.

The image digest is now included directly in each registry image reference instead of as a separate unformatted block.

Validation:
- actionlint -shellcheck=shellcheck .github/workflows/main.yml
- rendered the artifact note block locally with sample tag/digest values