### PR TITLE
Add Layer 4 Caddy modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH xcaddy build \
     --with github.com/lucaslorentz/caddy-docker-proxy/v2@v2.12.0 \
     --with github.com/caddy-dns/cloudflare@v0.2.4 \
     --with github.com/WeidiDeng/caddy-cloudflare-ip@v0.0.0-20231130002422-f53b62aa13cb \
+    --with github.com/mholt/caddy-l4@v0.1.0 \
     --with github.com/hslatman/caddy-crowdsec-bouncer/http@v0.12.1 \
     --with github.com/hslatman/caddy-crowdsec-bouncer/appsec@v0.12.1 \
+    --with github.com/hslatman/caddy-crowdsec-bouncer/layer4@v0.12.1 \
     --with github.com/ggicci/caddy-jwt@v1.1.2 \
     --with github.com/zhangjiayin/caddy-geoip2@v0.0.0-20251231005803-9e40d38250b4
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ The image is built from the repository `Dockerfile` with:
 - `github.com/lucaslorentz/caddy-docker-proxy/v2`
 - `github.com/caddy-dns/cloudflare`
 - `github.com/WeidiDeng/caddy-cloudflare-ip`
+- `github.com/mholt/caddy-l4`
 - `github.com/hslatman/caddy-crowdsec-bouncer/http`
 - `github.com/hslatman/caddy-crowdsec-bouncer/appsec`
+- `github.com/hslatman/caddy-crowdsec-bouncer/layer4`
 - `github.com/ggicci/caddy-jwt`
 - `github.com/zhangjiayin/caddy-geoip2`
 
@@ -195,6 +197,12 @@ That throttle prevents rapid Docker event bursts from causing repeated graceful 
 [`acquis.yaml`](acquis.yaml) is the minimal CrowdSec Docker acquisition file used by the example. It tells CrowdSec to read Caddy logs through `docker-socket-proxy` and classify them as Caddy logs.
 
 ## Advanced Patterns
+
+### Layer 4 Routing
+
+The image includes `caddy-l4` and the CrowdSec Layer 4 matcher for advanced TCP/UDP edge routing, such as SNI-based TCP proxying or non-HTTP services that should still be checked against CrowdSec decisions.
+
+The canonical Compose example stays HTTP-focused and does not expose Layer 4 listeners by default.
 
 ### Cloudflare Access JWT
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -24,6 +24,7 @@
       automerge: false,
     },
     {
+      description: 'Keep CrowdSec bouncer module updates together, including HTTP, AppSec, and Layer 4 packages',
       groupName: 'caddy-crowdsec-bouncer',
       matchPackageNames: [
         '/github\\.com/hslatman/caddy-crowdsec-bouncer/',


### PR DESCRIPTION
## Summary
- add caddy-l4 to the custom Caddy build
- add the CrowdSec Layer 4 matcher alongside the existing HTTP and AppSec bouncers
- document Layer 4 support as an advanced capability without changing the canonical Compose example
- clarify Renovate grouping for CrowdSec bouncer modules

## Validation
- go list -m -versions github.com/mholt/caddy-l4
- go list -m -versions github.com/hslatman/caddy-crowdsec-bouncer
- npx --yes --package renovate@43.141.6 -- renovate-config-validator --strict
- docker build --platform linux/arm64 -t caddy-proxy-cloudflare:l4-test .
- docker run --rm caddy-proxy-cloudflare:l4-test list-modules | grep -E '(^layer4|crowdsec)'