### PR TITLE
Add shell and binary smoke checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
       - "healthcheck.go"
       - ".github/workflows/main.yml"
       - "renovate.json5"
+      - "scripts/*.sh"
   pull_request:
     branches: [main]
 
@@ -44,6 +45,7 @@ jobs:
               - "healthcheck.go"
               - "healthcheck_test.go"
               - ".github/workflows/main.yml"
+              - "scripts/smoke-binary.sh"
             renovate:
               - ".github/workflows/main.yml"
               - "renovate.json5"
@@ -58,6 +60,23 @@ jobs:
         uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
         with:
           args: -shellcheck=shellcheck .github/workflows/main.yml
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run ShellCheck
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace:ro" \
+            -w /workspace \
+            docker.io/koalaman/shellcheck:v0.11.0@sha256:61862eba1fcf09a484ebcc6feea46f1782532571a34ed51fedf90dd25f925a8d \
+            scripts/*.sh
 
   buildx:
     runs-on: ubuntu-latest
@@ -146,11 +165,17 @@ jobs:
           sha256sum caddy-proxy-cloudflare-linux-* > checksums-sha256.txt
           cat checksums-sha256.txt
 
+      - name: Smoke binary artifacts
+        env:
+          CADDY_PROXY_SMOKE_REQUIRE_EXEC: "1"
+        run: scripts/smoke-binary.sh dist
+
   release-meta:
     runs-on: ubuntu-latest
     needs:
       - detect
       - actionlint
+      - shellcheck
     if: github.event_name == 'push' && needs.detect.outputs.build == 'true'
     permissions:
       contents: write
@@ -310,6 +335,11 @@ jobs:
           sha256sum caddy-proxy-cloudflare-linux-* > checksums-sha256.txt
           cat checksums-sha256.txt
 
+      - name: Smoke binary artifacts
+        env:
+          CADDY_PROXY_SMOKE_REQUIRE_EXEC: "1"
+        run: scripts/smoke-binary.sh dist
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -342,6 +372,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Download binary artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -350,12 +383,14 @@ jobs:
 
       - name: Verify downloaded binary artifacts
         shell: bash
+        env:
+          CADDY_PROXY_SMOKE_REQUIRE_EXEC: "1"
         run: |
           set -euo pipefail
 
-          cd dist
-          sha256sum --check checksums-sha256.txt
-          test -f checksums-sha256.txt.sigstore.json
+          test -f dist/checksums-sha256.txt.sigstore.json
+          chmod 0755 dist/caddy-proxy-cloudflare-linux-*
+          scripts/smoke-binary.sh dist
 
       - name: Create GitHub Release
         env:
@@ -411,6 +446,7 @@ jobs:
     needs:
       - detect
       - actionlint
+      - shellcheck
       - binary-check
       - buildx
       - release-meta
@@ -431,6 +467,7 @@ jobs:
           RELEASE_META_RESULT: ${{ needs.release-meta.result }}
           RELEASE_RESULT: ${{ needs.release.result }}
           RENOVATE_RESULT: ${{ needs.renovate.result }}
+          SHELLCHECK_RESULT: ${{ needs.shellcheck.result }}
         shell: bash
         run: |
           set -euo pipefail
@@ -442,6 +479,11 @@ jobs:
 
           if [[ "${ACTIONLINT_RESULT}" != "success" ]]; then
             echo "actionlint failed with result: ${ACTIONLINT_RESULT}" >&2
+            exit 1
+          fi
+
+          if [[ "${SHELLCHECK_RESULT}" != "success" ]]; then
+            echo "shellcheck failed with result: ${SHELLCHECK_RESULT}" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Quick install/update:
 curl -fsSL https://cpcf.shold.io | bash
 ```
 
-With flags:
+Non-interactive install with flags:
 
 ```bash
 curl -fsSL https://cpcf.shold.io | bash -s -- --yes --install-service --write-default-caddyfile --start

--- a/scripts/install-caddy-proxy-cloudflare.sh
+++ b/scripts/install-caddy-proxy-cloudflare.sh
@@ -78,20 +78,25 @@ prompt_yes_no() {
   local prompt="$1"
   local default="${2:-yes}"
   local answer
+  local suffix
 
   if [[ "${AUTO_YES}" == "true" ]]; then
     return 0
   fi
 
-  if [[ ! -t 0 ]]; then
+  if ! { : </dev/tty >/dev/tty; } 2>/dev/null; then
     return 1
   fi
 
   if [[ "${default}" == "yes" ]]; then
-    read -r -p "${prompt} [Y/n] " answer
+    suffix="[Y/n]"
+    printf "%s %s " "${prompt}" "${suffix}" >/dev/tty
+    IFS= read -r answer </dev/tty || return 1
     [[ -z "${answer}" || "${answer}" =~ ^[Yy]$ ]]
   else
-    read -r -p "${prompt} [y/N] " answer
+    suffix="[y/N]"
+    printf "%s %s " "${prompt}" "${suffix}" >/dev/tty
+    IFS= read -r answer </dev/tty || return 1
     [[ "${answer}" =~ ^[Yy]$ ]]
   fi
 }
@@ -104,8 +109,10 @@ confirm_or_exit() {
     return 0
   fi
 
-  if [[ ! -t 0 ]]; then
-    err "Refusing to modify the system non-interactively without --yes."
+  if ! { : </dev/tty >/dev/tty; } 2>/dev/null; then
+    err "Refusing to modify the system without an interactive terminal or --yes."
+    err "For interactive installs, run from a terminal: curl -fsSL https://cpcf.shold.io | bash"
+    err "For automation, use: curl -fsSL https://cpcf.shold.io | bash -s -- --yes"
     exit 1
   fi
 

--- a/scripts/smoke-binary.sh
+++ b/scripts/smoke-binary.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: smoke-binary.sh <dist-dir>
+
+Validates release binary artifacts for caddy-proxy-cloudflare.
+EOF
+}
+
+fail() {
+  printf "ERROR: %s\n" "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+dist_dir="$1"
+project="caddy-proxy-cloudflare"
+amd64_binary="${project}-linux-amd64"
+arm64_binary="${project}-linux-arm64"
+checksum_file="checksums-sha256.txt"
+
+required_modules=(
+  "docker_proxy"
+  "dns.providers.cloudflare"
+  "http.ip_sources.cloudflare"
+  "crowdsec"
+  "http.handlers.crowdsec"
+  "http.handlers.appsec"
+  "http.authentication.providers.jwt"
+  "geoip2"
+  "http.handlers.geoip2"
+  "layer4"
+  "layer4.matchers.crowdsec"
+)
+
+need_cmd grep
+need_cmd mktemp
+need_cmd sha256sum
+need_cmd uname
+
+[[ -d "${dist_dir}" ]] || fail "dist directory does not exist: ${dist_dir}"
+
+cd "${dist_dir}"
+
+for binary in "${amd64_binary}" "${arm64_binary}"; do
+  [[ -f "${binary}" ]] || fail "missing binary: ${binary}"
+  [[ -x "${binary}" ]] || fail "binary is not executable: ${binary}"
+done
+
+[[ -f "${checksum_file}" ]] || fail "missing checksum manifest: ${checksum_file}"
+
+for binary in "${amd64_binary}" "${arm64_binary}"; do
+  grep -Fq "  ${binary}" "${checksum_file}" || fail "checksum manifest does not include ${binary}"
+done
+
+sha256sum --check "${checksum_file}"
+
+case "$(uname -s)" in
+  Linux) host_os="linux" ;;
+  *) host_os="$(uname -s)" ;;
+esac
+
+case "$(uname -m)" in
+  x86_64 | amd64) host_arch="amd64" ;;
+  aarch64 | arm64) host_arch="arm64" ;;
+  *) host_arch="$(uname -m)" ;;
+esac
+
+if [[ "${host_os}/${host_arch}" != "linux/amd64" ]]; then
+  if [[ "${CADDY_PROXY_SMOKE_REQUIRE_EXEC:-0}" == "1" ]]; then
+    fail "executable smoke requires linux/amd64, got ${host_os}/${host_arch}"
+  fi
+
+  printf "Skipping executable smoke on %s/%s; linux/amd64 required\n" "${host_os}" "${host_arch}"
+  exit 0
+fi
+
+printf "Running %s version\n" "${amd64_binary}"
+"./${amd64_binary}" version
+
+modules_file="$(mktemp)"
+tmpdir="$(mktemp -d)"
+trap 'rm -f "${modules_file}"; rm -rf "${tmpdir}"' EXIT
+
+printf "Checking required Caddy modules\n"
+"./${amd64_binary}" list-modules > "${modules_file}"
+for module in "${required_modules[@]}"; do
+  grep -Fxq "${module}" "${modules_file}" || fail "missing Caddy module: ${module}"
+done
+
+cat > "${tmpdir}/Caddyfile" <<'EOF'
+{
+	auto_https off
+}
+
+:0 {
+	respond "ok"
+}
+EOF
+
+printf "Validating minimal Caddyfile\n"
+"./${amd64_binary}" validate --config "${tmpdir}/Caddyfile"
+
+printf "Binary smoke passed\n"


### PR DESCRIPTION
## Summary
- add a pinned ShellCheck CI job for repo scripts
- add a binary smoke script that validates checksums, required modules, and minimal Caddy config parsing
- run binary smoke in PR binary checks and release artifact verification
- keep the short installer one-liner interactive by prompting through /dev/tty

## Validation
- bash -n scripts/*.sh
- shellcheck scripts/*.sh
- pinned ShellCheck container
- pinned actionlint container
- binary export smoke for linux/amd64 and linux/arm64
- full linux/amd64 executable smoke in an Ubuntu container