### PR TITLE
Add compose-equivalent Caddyfile example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
               - "healthcheck.go"
               - "healthcheck_test.go"
               - ".github/workflows/main.yml"
+              - "examples/Caddyfile*"
               - "scripts/smoke-binary.sh"
             renovate:
               - ".github/workflows/main.yml"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Useful options:
 
 For systemd hosts without an existing Caddy service, `--install-service` creates a Caddyfile-based `caddy.service` following Caddy's [Linux service guidance](https://caddyserver.com/docs/running#linux-service). It does not overwrite an existing service unless `--force-service` is also set.
 
+For a plain Caddyfile starting point, [`examples/Caddyfile.compose-equivalent`](examples/Caddyfile.compose-equivalent) mirrors the main features from the canonical Compose labels in direct Caddyfile syntax.
+
 ## Compose Pattern
 
 The canonical example is [`docker-compose.yml`](docker-compose.yml). It uses a small edge stack:

--- a/examples/Caddyfile.compose-equivalent
+++ b/examples/Caddyfile.compose-equivalent
@@ -1,0 +1,37 @@
+# Compose-equivalent Caddyfile for host binary installs.
+#
+# Captured from the labels in ../docker-compose.yml, then sanitized with
+# placeholders and host-friendly upstream defaults. The Compose file remains the
+# canonical Docker example. Use this file when running the release binary
+# directly and you want the same Cloudflare, trusted proxy, CrowdSec, appsec,
+# compression, logging, and reverse proxy shape in plain Caddyfile syntax.
+{
+	acme_dns cloudflare {$CF_TOKEN}
+	crowdsec {
+		api_key {$CROWDSEC_API_KEY}
+		api_url {$CROWDSEC_API_URL:http://127.0.0.1:8080}
+		appsec_url {$CROWDSEC_APPSEC_URL:http://127.0.0.1:7422}
+	}
+	email {$EMAIL_ADDR:admin@example.com}
+	log {
+		output stdout
+	}
+	persist_config off
+	servers {
+		client_ip_headers Cf-Connecting-Ip
+		trusted_proxies static 173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20 197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13 104.24.0.0/14 172.64.0.0/13 131.0.72.0/22
+	}
+	tls_resolvers 1.1.1.1 1.0.0.1
+}
+
+whoami.{$DOMAIN} {
+	encode zstd gzip
+	log
+	route {
+		crowdsec
+		appsec
+		reverse_proxy {$WHOAMI_UPSTREAM:127.0.0.1:8080} {
+			header_up X-Forwarded-For {client_ip}
+		}
+	}
+}

--- a/scripts/smoke-binary.sh
+++ b/scripts/smoke-binary.sh
@@ -23,11 +23,13 @@ if [[ $# -ne 1 ]]; then
   exit 2
 fi
 
+repo_root="$(pwd)"
 dist_dir="$1"
 project="caddy-proxy-cloudflare"
 amd64_binary="${project}-linux-amd64"
 arm64_binary="${project}-linux-arm64"
 checksum_file="checksums-sha256.txt"
+compose_equivalent_caddyfile="${repo_root}/examples/Caddyfile.compose-equivalent"
 
 required_modules=(
   "docker_proxy"
@@ -110,5 +112,14 @@ EOF
 
 printf "Validating minimal Caddyfile\n"
 "./${amd64_binary}" validate --config "${tmpdir}/Caddyfile"
+
+if [[ -f "${compose_equivalent_caddyfile}" ]]; then
+  printf "Validating compose-equivalent Caddyfile\n"
+  DOMAIN=example.com \
+    EMAIL_ADDR=admin@example.com \
+    CF_TOKEN=0123456789abcdef0123456789abcdef01234567 \
+    CROWDSEC_API_KEY=example-crowdsec-key \
+    "./${amd64_binary}" validate --config "${compose_equivalent_caddyfile}"
+fi
 
 printf "Binary smoke passed\n"


### PR DESCRIPTION
## Summary
- add a host-binary Caddyfile example captured from the canonical Compose labels and sanitized with placeholders
- reference the example from the host binary install section
- validate the example through the existing binary smoke path when Caddyfile examples change

## Validation
- ran temporary Compose stack with stub values to capture caddy-docker-proxy's generated Caddyfile
- bash -n scripts/*.sh
- shellcheck scripts/*.sh
- pinned ShellCheck container
- pinned actionlint container
- full linux/amd64 binary smoke in Ubuntu container