### PR TITLE
docs: switch socket proxy example to wollomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,19 +156,16 @@ ports:
 
 ## Docker Socket Proxy
 
-The example uses [`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy) as a blast-radius reduction layer between the edge stack and Docker. It keeps the raw Docker socket out of Caddy and CrowdSec while still allowing the Docker reads they need for label discovery, event watching, network discovery, and Docker log acquisition.
+The example uses [`wollomatic/socket-proxy`](https://github.com/wollomatic/socket-proxy) as a blast-radius reduction layer between the edge stack and Docker. It keeps the raw Docker socket out of Caddy and CrowdSec while still allowing the Docker reads they need for label discovery, event watching, network discovery, and Docker log acquisition.
 
 The proxy is attached only to the internal `edge` network and has no host port mapping. Its Docker API surface is intentionally narrow:
 
 ```yaml
-environment:
-  - CONTAINERS=1
-  - EVENTS=1
-  - INFO=1
-  - NETWORKS=1
-  - PING=1
-  - VERSION=1
-  - POST=0
+command:
+  - "-listenip=0.0.0.0"
+  - "-allowfrom=caddy,crowdsec"
+  - "-allowHEAD=^(/v[0-9.]+)?/_ping$"
+  - "-allowGET=^(/v[0-9.]+)?/(info|version|containers/json|containers/[^/]+/json|containers/[^/]+/logs|networks/[^/]+|events)(\\?.*)?$"
 ```
 
 This allows required read paths such as container list/inspect/logs, Docker events, Docker info/version, and network reads. It blocks mutating Docker API calls and leaves broad sections such as images, volumes, exec, services, tasks, swarm, secrets, build, and auth disabled.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
 
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: ghcr.io/tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
+    image: ghcr.io/wollomatic/socket-proxy:1.12.0@sha256:e83ef9a87bf2e99b70428fd25f91fb167b75d4a45d28046c7bd2ff09d2d7b486
     user: 65532:65532
     group_add:
       - "${DOCKER_GID}"
@@ -120,18 +120,16 @@ services:
     tmpfs:
       - /run:uid=65532,gid=65532
       - /tmp:uid=65532,gid=65532,mode=1777
-      - /var/lib/haproxy:uid=65532,gid=65532
     networks:
       - edge
-    environment:
-      - CONTAINERS=1
-      - EVENTS=1
-      - INFO=1
-      - NETWORKS=1
-      - PING=1
-      - VERSION=1
-      - POST=0
-      - LOG_LEVEL=info
+    command:
+      - "-listenip=0.0.0.0"
+      - "-allowfrom=caddy,crowdsec"
+      - "-allowHEAD=^(/v[0-9.]+)?/_ping$"
+      - "-allowGET=^(/v[0-9.]+)?/(info|version|containers/json|containers/[^/]+/json|containers/[^/]+/logs|networks/[^/]+|events)(\\?.*)?$"
+      - "-loglevel=INFO"
+      - "-watchdoginterval=60"
+      - "-stoponwatchdog"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped

--- a/renovate.json5
+++ b/renovate.json5
@@ -19,7 +19,7 @@
         'docker',
       ],
       matchPackageNames: [
-        '/tecnativa\\/docker-socket-proxy/',
+        '/wollomatic\\/socket-proxy/',
       ],
       automerge: false,
     },


### PR DESCRIPTION
## Summary
- update the canonical Compose example to use wollomatic/socket-proxy with the live-tested strict Docker API allowlist
- remove the old Tecnativa socket proxy image, environment flags, and HAProxy tmpfs
- update README and Renovate manual-review matching for the new socket proxy image

## Validation
- docker compose -f docker-compose.yml config --quiet
- npx --yes --package renovate@43.141.6 -- renovate-config-validator --strict
- git diff --check